### PR TITLE
Add filter for hidden tags.

### DIFF
--- a/app/src/main/java/apps/amine/bou/readerforselfoss/HomeActivity.kt
+++ b/app/src/main/java/apps/amine/bou/readerforselfoss/HomeActivity.kt
@@ -819,6 +819,12 @@ class HomeActivity : AppCompatActivity(), SearchView.OnQueryTextListener {
         }
     }
 
+    private fun filter(tags: String, hidden: String): Boolean {
+      val tagsList = tags.replace("\\s".toRegex(), "").split(",")
+      val hiddenList = hidden.replace("\\s".toRegex(), "").split(",")
+      return tagsList.intersect(hiddenList).isEmpty()
+    }
+
     private fun doCallTo(
         appendResults: Boolean,
         toastMessage: Int,
@@ -829,6 +835,10 @@ class HomeActivity : AppCompatActivity(), SearchView.OnQueryTextListener {
             if (response.body() != null) {
                 if (shouldUpdate) {
                     items = response.body() as ArrayList<Item>
+                    val hiddenTags = sharedPref.getString("hidden_tags", "")
+                    items = items.filter {
+                      maybeTagFilter != null || filter(it.tags, hiddenTags)
+                    } as ArrayList<Item>
 
                     if (allItems.isEmpty()) {
                         allItems = items

--- a/app/src/main/java/apps/amine/bou/readerforselfoss/settings/SettingsActivity.java
+++ b/app/src/main/java/apps/amine/bou/readerforselfoss/settings/SettingsActivity.java
@@ -181,6 +181,7 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
                         }
                     }
             });
+
         }
 
         @Override

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -127,6 +127,7 @@
     <string name="self_signed_cert_warning">Due to security reasons, self signed certificates are not supported by default. By activating this, I\'ll not be responsible of any security problem you encounter.</string>
     <string name="pref_selfoss_category">Selfoss Api</string>
     <string name="pref_api_items_number_title">Loaded items number</string>
+    <string name="pref_hidden_tags">Hidden tags, comma separated.</string>
     <string name="read_debug_title">Read articles appearing as unread ?</string>
     <string name="read_debug_off">No log when marking an item as read</string>
     <string name="read_debug_on">Api calls will be logged when marking an article as read</string>

--- a/app/src/main/res/xml/pref_general.xml
+++ b/app/src/main/res/xml/pref_general.xml
@@ -12,6 +12,13 @@
         android:singleLine="true"
         android:title="@string/pref_api_items_number_title" />
 
+    <EditTextPreference
+        android:defaultValue=""
+        android:key="hidden_tags"
+        android:selectAllOnFocus="true"
+        android:singleLine="true"
+        android:title="@string/pref_hidden_tags" />
+
     <SwitchPreference
         android:defaultValue="false"
         android:key="infinite_loading"


### PR DESCRIPTION
This commit adds the option to configure hidden tags. Articles tagged
with these hidden tags won't appear in the list of articles by default.
To see these articles the user must explicitly filter by those tags.

## Types of changes

- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [] I have updated the documentation accordingly.
- [] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This is **NOT** translation related. (See [here](https://github.com/aminecmi/ReaderforSelfoss/pull/170#issuecomment-355715654))
