### PR TITLE
Add EXTRA_SUBJECT when sharing link

### DIFF
--- a/app/src/main/java/apps/amine/bou/readerforselfoss/adapters/ItemCardAdapter.kt
+++ b/app/src/main/java/apps/amine/bou/readerforselfoss/adapters/ItemCardAdapter.kt
@@ -179,7 +179,8 @@ class ItemCardAdapter(
             })
 
             mView.shareBtn.setOnClickListener {
-                c.shareLink(items[adapterPosition].getLinkDecoded())
+                val item = items[adapterPosition]
+                c.shareLink(item.getLinkDecoded(), item.title)
             }
 
             mView.browserBtn.setOnClickListener {

--- a/app/src/main/java/apps/amine/bou/readerforselfoss/fragments/ArticleFragment.kt
+++ b/app/src/main/java/apps/amine/bou/readerforselfoss/fragments/ArticleFragment.kt
@@ -139,7 +139,7 @@ class ArticleFragment : Fragment() {
                 override fun onItemClick(item: MenuItem) {
                     when (item.itemId) {
                         R.id.more_action -> getContentFromMercury(customTabsIntent, prefs)
-                        R.id.share_action -> activity!!.shareLink(url)
+                        R.id.share_action -> activity!!.shareLink(url, contentTitle)
                         R.id.open_action -> activity!!.openItemUrl(
                             allItems,
                             pageNumber.toInt(),

--- a/app/src/main/java/apps/amine/bou/readerforselfoss/utils/AppUtils.kt
+++ b/app/src/main/java/apps/amine/bou/readerforselfoss/utils/AppUtils.kt
@@ -25,11 +25,12 @@ fun String.toStringUriWithHttp(): String =
         this
     }
 
-fun Context.shareLink(itemUrl: String) {
+fun Context.shareLink(itemUrl: String, itemTitle: String) {
     val sendIntent = Intent()
     sendIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
     sendIntent.action = Intent.ACTION_SEND
     sendIntent.putExtra(Intent.EXTRA_TEXT, itemUrl.toStringUriWithHttp())
+    sendIntent.putExtra(Intent.EXTRA_SUBJECT, itemTitle)
     sendIntent.type = "text/plain"
     startActivity(
         Intent.createChooser(


### PR DESCRIPTION
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This is **NOT** translation related. (See [here](https://github.com/aminecmi/ReaderforSelfoss/pull/170#issuecomment-355715654))

This closes issue [ ] / This is implements feature [ ] / This finishes chore [ ]

Hi @aminecmi, here is a simple hack, to add a default "subject" to email when you share an article by email. The default subject will be the article title.

This is my first PR on ReaderforSelfoss, so feel free to ask for any informations / modifications or anything else.

Here is an example of resulting email :
![image](https://user-images.githubusercontent.com/6597721/48664548-801f4500-eaa0-11e8-9f90-5e03fc154b51.png)

I have tested it on the 2 buttons : in "Card view" mode ; and when displaying article content.

Have a nice day & thank you for your excellent software