### PR TITLE
Get version for current tree state not latest

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,7 +2,7 @@ buildscript {
 }
 
 def gitVersion() {
-    def process = "git for-each-ref refs/tags --sort=-authordate --format='%(refname:short)' --count=1".execute()
+    def process = "git describe --contains $(git rev-parse HEAD)".execute()
     return process.text.replaceAll("'", "").substring(1).replaceAll("\\.", "").trim()
 }
 


### PR DESCRIPTION
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [-] I have updated the documentation accordingly.
- [-] I have added tests to cover my changes.
- [?] All new and existing tests passed.
- [x] This is **NOT** translation related. (See [here](https://github.com/aminecmi/ReaderforSelfoss/pull/170#issuecomment-355715654))

Eg. I want to build v17181133**2**1, I checkout v17181133**2**1, but the command yields v17181133**3**1.

Ref: https://gitlab.com/fdroid/fdroiddata/commit/54d39c04b9e1cb71e3318d7a2ee02bccf42b1451 and https://f-droid.org/wiki/page/apps.amine.bou.readerforselfoss/lastbuild_1718113321
