### PR TITLE
Fix back button closing settings from submenu

### DIFF
--- a/app/src/main/java/apps/amine/bou/readerforselfoss/settings/SettingsActivity.java
+++ b/app/src/main/java/apps/amine/bou/readerforselfoss/settings/SettingsActivity.java
@@ -301,7 +301,7 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
                 editor.remove("color_accent_dark");
                 editor.remove("dark_theme");
                 editor.apply();
-                getActivity().finish();
+                getActivity().recreate();
             }
             return super.onOptionsItemSelected(item);
         }

--- a/app/src/main/java/apps/amine/bou/readerforselfoss/settings/SettingsActivity.java
+++ b/app/src/main/java/apps/amine/bou/readerforselfoss/settings/SettingsActivity.java
@@ -195,16 +195,6 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
             });
 
         }
-
-        @Override
-        public boolean onOptionsItemSelected(MenuItem item) {
-            int id = item.getItemId();
-            if (id == android.R.id.home) {
-                getActivity().finish();
-                return true;
-            }
-            return super.onOptionsItemSelected(item);
-        }
     }
 
     @TargetApi(Build.VERSION_CODES.HONEYCOMB)
@@ -244,16 +234,6 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
                         }
                     }
             });
-        }
-
-        @Override
-        public boolean onOptionsItemSelected(MenuItem item) {
-            int id = item.getItemId();
-            if (id == android.R.id.home) {
-                getActivity().finish();
-                return true;
-            }
-            return super.onOptionsItemSelected(item);
         }
     }
 
@@ -298,16 +278,6 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
                 }
             });
         }
-
-        @Override
-        public boolean onOptionsItemSelected(MenuItem item) {
-            int id = item.getItemId();
-            if (id == android.R.id.home) {
-                getActivity().finish();
-                return true;
-            }
-            return super.onOptionsItemSelected(item);
-        }
     }
 
     @TargetApi(Build.VERSION_CODES.HONEYCOMB)
@@ -322,10 +292,7 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
         @Override
         public boolean onOptionsItemSelected(MenuItem item) {
             int id = item.getItemId();
-            if (id == android.R.id.home) {
-                getActivity().finish();
-                return true;
-            } else if (id == R.id.clear) {
+            if (id == R.id.clear) {
                 SharedPreferences pref = PreferenceManager.getDefaultSharedPreferences(getActivity());
                 SharedPreferences.Editor editor = pref.edit();
                 editor.remove("color_primary");
@@ -353,16 +320,6 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
             addPreferencesFromResource(R.xml.pref_offline);
             setHasOptionsMenu(true);
         }
-
-        @Override
-        public boolean onOptionsItemSelected(MenuItem item) {
-            int id = item.getItemId();
-            if (id == android.R.id.home) {
-                getActivity().finish();
-                return true;
-            }
-            return super.onOptionsItemSelected(item);
-        }
     }
 
     @TargetApi(Build.VERSION_CODES.HONEYCOMB)
@@ -372,16 +329,6 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
             super.onCreate(savedInstanceState);
             addPreferencesFromResource(R.xml.pref_experimental);
             setHasOptionsMenu(true);
-        }
-
-        @Override
-        public boolean onOptionsItemSelected(MenuItem item) {
-            int id = item.getItemId();
-            if (id == android.R.id.home) {
-                getActivity().finish();
-                return true;
-            }
-            return super.onOptionsItemSelected(item);
         }
     }
 

--- a/app/src/main/java/apps/amine/bou/readerforselfoss/settings/SettingsActivity.java
+++ b/app/src/main/java/apps/amine/bou/readerforselfoss/settings/SettingsActivity.java
@@ -390,7 +390,7 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
     public boolean onOptionsItemSelected(MenuItem item) {
         int id = item.getItemId();
         if (id == android.R.id.home) {
-            finish();
+            super.onBackPressed();
             return true;
         }
         return super.onOptionsItemSelected(item);


### PR DESCRIPTION
## Types of changes

- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] This is **NOT** translation related. (See [here](https://github.com/aminecmi/ReaderforSelfoss/pull/170#issuecomment-355715654))

This closes issue #290 

I tested this on my device and it works fine. Now the back arrow in the settings works as expected.
Pressing the button to reset the theme doesn't change page anymore, though my fix introduced a black blink after pushing the button. It is not very nice to see but I could not find another way to refresh the colors after pushing it...
You may discard the last commit if you'd rather not have such a blink and keep it as it worked before.