### PR TITLE
Position of the elements in list view fixed in place.

### DIFF
--- a/app/src/main/java/apps/amine/bou/readerforselfoss/adapters/ItemListAdapter.kt
+++ b/app/src/main/java/apps/amine/bou/readerforselfoss/adapters/ItemListAdapter.kt
@@ -79,23 +79,6 @@ class ItemListAdapter(
         holder.mView.sourceTitleAndDate.text = itm.sourceAndDateText()
 
         if (itm.getThumbnail(c).isEmpty()) {
-            val sizeInInt = 46
-            val sizeInDp = TypedValue.applyDimension(
-                TypedValue.COMPLEX_UNIT_DIP, sizeInInt.toFloat(), c.resources
-                    .displayMetrics
-            ).toInt()
-
-            val marginInInt = 16
-            val marginInDp = TypedValue.applyDimension(
-                TypedValue.COMPLEX_UNIT_DIP, marginInInt.toFloat(), c.resources
-                    .displayMetrics
-            ).toInt()
-
-            val params = holder.mView.itemImage.layoutParams as ViewGroup.MarginLayoutParams
-            params.height = sizeInDp
-            params.width = sizeInDp
-            params.setMargins(marginInDp, 0, 0, 0)
-            holder.mView.itemImage.layoutParams = params
 
             if (itm.getIcon(c).isEmpty()) {
                 val color = generator.getColor(itm.sourcetitle)

--- a/app/src/main/res/layout/list_item.xml
+++ b/app/src/main/res/layout/list_item.xml
@@ -3,14 +3,14 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:minHeight="88dp">
-
+    android:layout_height="88dp">
 
     <ImageView
         android:id="@+id/itemImage"
-        android:layout_width="88dp"
-        android:layout_height="88dp"
+        android:layout_width="46dp"
+        android:layout_height="46dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="21dp"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
@@ -18,9 +18,9 @@
         android:id="@+id/title"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginEnd="16dp"
-        android:layout_marginStart="16dp"
+        android:layout_marginStart="8dp"
         android:layout_marginTop="8dp"
+        android:layout_marginEnd="16dp"
         android:ellipsize="end"
         android:fontFamily="sans-serif"
         android:gravity="start"
@@ -39,16 +39,17 @@
         android:id="@+id/sourceTitleAndDate"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
-        android:layout_marginTop="8dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="66dp"
         android:layout_marginEnd="16dp"
         android:gravity="start"
+        android:maxLines="1"
         android:textAlignment="viewStart"
         android:textSize="14sp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toEndOf="@+id/itemImage"
-        app:layout_constraintTop_toBottomOf="@+id/title"
+        app:layout_constraintTop_toTopOf="parent"
         tools:text="Google Actualité Il y a 5h" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## Types of changes

- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] This is **NOT** translation related. (See [here](https://github.com/aminecmi/ReaderforSelfoss/pull/170#issuecomment-355715654))

This closes issue #287 

The elements in list view were positioned dynamically even though the dimension of the list element were fixed.
I gave some fixed positions to the elements, so they are not free to move wherever they want. In my opinion this is better looking as the whole list assumes an ordered and uniform disposition.
I vertically centered the position of the icon as well, I think it looks better this way.
As I modified it, the title of the articles may be long up to three lines and the sources&date only one. We may change it for 2 and 2, but if more is needed then the height of the list element should be modified.

You may check my screenshots to see the difference,
BEFORE:
![before](https://user-images.githubusercontent.com/13107368/101527070-d57f6500-398d-11eb-8e60-737472ff97e0.jpg)

AFTER:
![after](https://user-images.githubusercontent.com/13107368/101527095-dd3f0980-398d-11eb-93b7-7e5d182cda96.jpg)

