### PR TITLE
Expand images on tap

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -138,6 +138,9 @@ dependencies {
     // Pager
     implementation 'me.relex:circleindicator:2.0.0@aar'
 
+    //PhotoView
+    implementation 'com.github.chrisbanes:PhotoView:2.0.0'
+
     implementation 'androidx.core:core-ktx:1.1.0-beta01'
 
     implementation "androidx.lifecycle:lifecycle-livedata:$lifecycle_version"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -102,6 +102,7 @@ dependencies {
     implementation "androidx.browser:browser:$android_version"
     implementation "androidx.cardview:cardview:$android_version"
     implementation 'androidx.constraintlayout:constraintlayout:2.0.0-alpha5'
+    implementation 'org.jsoup:jsoup:1.13.1'
 
     //multidex
     implementation 'androidx.multidex:multidex:2.0.1'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -62,6 +62,9 @@
         <activity
             android:name=".ReaderActivity">
         </activity>
+        <activity
+            android:name=".ImageActivity">
+        </activity>
 
         <meta-data
             android:name="apps.amine.bou.readerforselfoss.utils.glide.SelfSignedGlideModule"

--- a/app/src/main/java/apps/amine/bou/readerforselfoss/ImageActivity.kt
+++ b/app/src/main/java/apps/amine/bou/readerforselfoss/ImageActivity.kt
@@ -1,0 +1,52 @@
+package apps.amine.bou.readerforselfoss
+
+import android.os.Bundle
+import android.view.MenuItem
+import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.FragmentManager
+import androidx.fragment.app.FragmentStatePagerAdapter
+import apps.amine.bou.readerforselfoss.fragments.ImageFragment
+import kotlinx.android.synthetic.main.activity_reader.*
+
+class ImageActivity : AppCompatActivity() {
+    private lateinit var allImages : ArrayList<String>
+    private var position : Int = 0
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setContentView(R.layout.activity_image)
+
+        setSupportActionBar(toolBar)
+        supportActionBar?.setDisplayShowTitleEnabled(false)
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+
+        allImages = intent.getStringArrayListExtra("allImages")
+        position = intent.getIntExtra("position", 0)
+
+        pager.adapter = ScreenSlidePagerAdapter(supportFragmentManager)
+        pager.currentItem = position
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        when (item.itemId) {
+            android.R.id.home -> {
+                onBackPressed()
+                return true
+            }
+        }
+
+        return super.onOptionsItemSelected(item)
+    }
+
+    private inner class ScreenSlidePagerAdapter(fm: FragmentManager) : FragmentStatePagerAdapter(fm, FragmentStatePagerAdapter.BEHAVIOR_RESUME_ONLY_CURRENT_FRAGMENT) {
+
+        override fun getCount(): Int {
+            return allImages.size
+        }
+
+        override fun getItem(position: Int): ImageFragment {
+            return ImageFragment.newInstance(allImages[position])
+        }
+    }
+}

--- a/app/src/main/java/apps/amine/bou/readerforselfoss/api/selfoss/SelfossModels.kt
+++ b/app/src/main/java/apps/amine/bou/readerforselfoss/api/selfoss/SelfossModels.kt
@@ -5,7 +5,6 @@ import android.net.Uri
 import android.os.Parcel
 import android.os.Parcelable
 import android.text.Html
-import android.util.Log
 import android.webkit.URLUtil
 import org.jsoup.Jsoup
 
@@ -145,20 +144,17 @@ data class Item(
 
     fun preloadImages(context: Context) : Boolean {
         val imageUrls = this.getImages()
-        Log.d("Carica", "Caricando immagini")
 
         val glideOptions = RequestOptions.diskCacheStrategyOf(DiskCacheStrategy.ALL)
 
 
         try {
             for (url in imageUrls) {
-                Log.d("Carica", url)
                 if ( URLUtil.isValidUrl(url)) {
                     val image = Glide.with(context).asBitmap()
                             .apply(glideOptions)
                             .load(url).submit().get()
                 }
-                Log.d("Carica", "Immagine presa")
             }
         } catch (e : Error) {
             return false

--- a/app/src/main/java/apps/amine/bou/readerforselfoss/api/selfoss/SelfossModels.kt
+++ b/app/src/main/java/apps/amine/bou/readerforselfoss/api/selfoss/SelfossModels.kt
@@ -5,6 +5,7 @@ import android.net.Uri
 import android.os.Parcel
 import android.os.Parcelable
 import android.text.Html
+import org.jsoup.Jsoup
 
 import apps.amine.bou.readerforselfoss.utils.Config
 import apps.amine.bou.readerforselfoss.utils.isEmptyOrNullOrNullString
@@ -126,6 +127,15 @@ data class Item(
             config = Config(app)
         }
         return constructUrl(config, "thumbnails", thumbnail)
+    }
+
+    fun getImages() : ArrayList<String> {
+        var allImages = ArrayList<String>()
+
+        for ( image in Jsoup.parse(content).getElementsByTag("img")) {
+            allImages.add(image.attr("src"))
+        }
+        return allImages
     }
 
     fun getTitleDecoded(): String {

--- a/app/src/main/java/apps/amine/bou/readerforselfoss/api/selfoss/SelfossModels.kt
+++ b/app/src/main/java/apps/amine/bou/readerforselfoss/api/selfoss/SelfossModels.kt
@@ -5,10 +5,15 @@ import android.net.Uri
 import android.os.Parcel
 import android.os.Parcelable
 import android.text.Html
+import android.util.Log
+import android.webkit.URLUtil
 import org.jsoup.Jsoup
 
 import apps.amine.bou.readerforselfoss.utils.Config
 import apps.amine.bou.readerforselfoss.utils.isEmptyOrNullOrNullString
+import com.bumptech.glide.Glide
+import com.bumptech.glide.load.engine.DiskCacheStrategy
+import com.bumptech.glide.request.RequestOptions
 import com.google.gson.annotations.SerializedName
 
 private fun constructUrl(config: Config?, path: String, file: String?): String {
@@ -136,6 +141,30 @@ data class Item(
             allImages.add(image.attr("src"))
         }
         return allImages
+    }
+
+    fun preloadImages(context: Context) : Boolean {
+        val imageUrls = this.getImages()
+        Log.d("Carica", "Caricando immagini")
+
+        val glideOptions = RequestOptions.diskCacheStrategyOf(DiskCacheStrategy.ALL)
+
+
+        try {
+            for (url in imageUrls) {
+                Log.d("Carica", url)
+                if ( URLUtil.isValidUrl(url)) {
+                    val image = Glide.with(context).asBitmap()
+                            .apply(glideOptions)
+                            .load(url).submit().get()
+                }
+                Log.d("Carica", "Immagine presa")
+            }
+        } catch (e : Error) {
+            return false
+        }
+
+        return true
     }
 
     fun getTitleDecoded(): String {

--- a/app/src/main/java/apps/amine/bou/readerforselfoss/background/background.kt
+++ b/app/src/main/java/apps/amine/bou/readerforselfoss/background/background.kt
@@ -104,6 +104,7 @@ class LoadingWorker(val context: Context, params: WorkerParameters) : Worker(con
                                     notificationManager.notify(2, newItemsNotification.build())
                                 }
                             }
+                            apiItems.map {it.preloadImages(context)}
                         }
                         Timer("", false).schedule(4000) {
                             notificationManager.cancel(1)

--- a/app/src/main/java/apps/amine/bou/readerforselfoss/fragments/ArticleFragment.kt
+++ b/app/src/main/java/apps/amine/bou/readerforselfoss/fragments/ArticleFragment.kt
@@ -9,16 +9,12 @@ import android.graphics.drawable.ColorDrawable
 import android.os.Build
 import android.os.Bundle
 import android.preference.PreferenceManager
-import android.view.InflateException
+import android.view.*
 import androidx.browser.customtabs.CustomTabsIntent
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import androidx.fragment.app.Fragment
 import androidx.core.content.ContextCompat
 import androidx.core.widget.NestedScrollView
-import android.view.LayoutInflater
-import android.view.MenuItem
-import android.view.View
-import android.view.ViewGroup
 import android.webkit.WebSettings
 import androidx.appcompat.app.AlertDialog
 import androidx.core.content.res.ResourcesCompat
@@ -44,6 +40,7 @@ import apps.amine.bou.readerforselfoss.utils.openItemUrl
 import apps.amine.bou.readerforselfoss.utils.shareLink
 import apps.amine.bou.readerforselfoss.utils.sourceAndDateText
 import apps.amine.bou.readerforselfoss.utils.succeeded
+import android.webkit.WebView
 import com.bumptech.glide.Glide
 import com.bumptech.glide.request.RequestOptions
 import com.github.rubensousa.floatingtoolbar.FloatingToolbar
@@ -410,6 +407,14 @@ class ArticleFragment : Fragment() {
         rootView!!.webcontent.settings.loadWithOverviewMode = true
         rootView!!.webcontent.settings.javaScriptEnabled = false
 
+        val gestureDetector = GestureDetector(activity, object : GestureDetector.SimpleOnGestureListener() {
+            override fun onSingleTapUp(e: MotionEvent?): Boolean {
+                return performClick()
+            }
+        })
+
+        rootView!!.webcontent.setOnTouchListener { _, event -> gestureDetector.onTouchEvent(event)}
+
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
             rootView!!.webcontent.settings.layoutAlgorithm =
                     WebSettings.LayoutAlgorithm.TEXT_AUTOSIZING
@@ -523,6 +528,15 @@ class ArticleFragment : Fragment() {
             fragment.arguments = args
             return fragment
         }
+    }
+
+    fun performClick(): Boolean {
+        if (rootView!!.webcontent.hitTestResult.type == WebView.HitTestResult.IMAGE_TYPE ||
+                rootView!!.webcontent.hitTestResult.type == WebView.HitTestResult.SRC_IMAGE_ANCHOR_TYPE) {
+            //TODO: Add a way to show the image in full screen
+            return true
+        }
+        return false
     }
 
 

--- a/app/src/main/java/apps/amine/bou/readerforselfoss/fragments/ArticleFragment.kt
+++ b/app/src/main/java/apps/amine/bou/readerforselfoss/fragments/ArticleFragment.kt
@@ -539,7 +539,7 @@ class ArticleFragment : Fragment() {
             val position : Int = 0
 
             fragmentManager!!.beginTransaction().replace(R.id.reader_activity_view, ImageFragment.newInstance(position, allImages)).addToBackStack(null).commit()
-            return true
+            return false
         }
         return false
     }

--- a/app/src/main/java/apps/amine/bou/readerforselfoss/fragments/ArticleFragment.kt
+++ b/app/src/main/java/apps/amine/bou/readerforselfoss/fragments/ArticleFragment.kt
@@ -22,6 +22,7 @@ import androidx.core.widget.NestedScrollView
 import androidx.appcompat.app.AlertDialog
 import androidx.core.content.res.ResourcesCompat
 import androidx.room.Room
+import apps.amine.bou.readerforselfoss.ImageActivity
 import apps.amine.bou.readerforselfoss.R
 import apps.amine.bou.readerforselfoss.api.mercury.MercuryApi
 import apps.amine.bou.readerforselfoss.api.mercury.ParsedContent
@@ -577,8 +578,10 @@ class ArticleFragment : Fragment() {
 
             val position : Int = allImages.indexOf(rootView!!.webcontent.hitTestResult.extra)
 
-
-            fragmentManager!!.beginTransaction().replace(R.id.reader_activity_view, ImageFragment.newInstance(position, allImages)).addToBackStack(null).commit()
+            val intent = Intent(activity, ImageActivity::class.java)
+            intent.putExtra("allImages", allImages)
+            intent.putExtra("position", position)
+            startActivity(intent)
             return false
         }
         return false

--- a/app/src/main/java/apps/amine/bou/readerforselfoss/fragments/ArticleFragment.kt
+++ b/app/src/main/java/apps/amine/bou/readerforselfoss/fragments/ArticleFragment.kt
@@ -533,7 +533,12 @@ class ArticleFragment : Fragment() {
     fun performClick(): Boolean {
         if (rootView!!.webcontent.hitTestResult.type == WebView.HitTestResult.IMAGE_TYPE ||
                 rootView!!.webcontent.hitTestResult.type == WebView.HitTestResult.SRC_IMAGE_ANCHOR_TYPE) {
-            //TODO: Add a way to show the image in full screen
+            //TODO: Transfer all images in the webpage to the Image fragment
+            var allImages = ArrayList<String>()
+            allImages.add(rootView!!.webcontent.hitTestResult.extra.toString())
+            val position : Int = 0
+
+            fragmentManager!!.beginTransaction().replace(R.id.reader_activity_view, ImageFragment.newInstance(position, allImages)).addToBackStack(null).commit()
             return true
         }
         return false

--- a/app/src/main/java/apps/amine/bou/readerforselfoss/fragments/ArticleFragment.kt
+++ b/app/src/main/java/apps/amine/bou/readerforselfoss/fragments/ArticleFragment.kt
@@ -1,11 +1,13 @@
 package apps.amine.bou.readerforselfoss.fragments
 
 import android.content.Context
+import android.content.Intent
 import android.content.SharedPreferences
 import android.content.res.ColorStateList
 import android.content.res.TypedArray
 import android.graphics.Typeface
 import android.graphics.drawable.ColorDrawable
+import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.preference.PreferenceManager
@@ -41,6 +43,7 @@ import apps.amine.bou.readerforselfoss.utils.shareLink
 import apps.amine.bou.readerforselfoss.utils.sourceAndDateText
 import apps.amine.bou.readerforselfoss.utils.succeeded
 import android.webkit.WebView
+import android.webkit.WebViewClient
 import com.bumptech.glide.Glide
 import com.bumptech.glide.request.RequestOptions
 import com.github.rubensousa.floatingtoolbar.FloatingToolbar
@@ -406,6 +409,15 @@ class ArticleFragment : Fragment() {
         rootView!!.webcontent.settings.useWideViewPort = true
         rootView!!.webcontent.settings.loadWithOverviewMode = true
         rootView!!.webcontent.settings.javaScriptEnabled = false
+
+        rootView!!.webcontent.webViewClient = object : WebViewClient() {
+            override fun shouldOverrideUrlLoading(view: WebView?, url : String): Boolean {
+                if (rootView!!.webcontent.hitTestResult.type != WebView.HitTestResult.SRC_IMAGE_ANCHOR_TYPE) {
+                    rootView!!.context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
+                }
+                return true
+            }
+        }
 
         val gestureDetector = GestureDetector(activity, object : GestureDetector.SimpleOnGestureListener() {
             override fun onSingleTapUp(e: MotionEvent?): Boolean {

--- a/app/src/main/java/apps/amine/bou/readerforselfoss/fragments/ArticleFragment.kt
+++ b/app/src/main/java/apps/amine/bou/readerforselfoss/fragments/ArticleFragment.kt
@@ -53,6 +53,7 @@ import retrofit2.Callback
 import retrofit2.Response
 import java.net.MalformedURLException
 import java.net.URL
+import kotlin.collections.ArrayList
 import kotlin.concurrent.thread
 
 class ArticleFragment : Fragment() {
@@ -65,6 +66,7 @@ class ArticleFragment : Fragment() {
     private lateinit var contentSource: String
     private lateinit var contentImage: String
     private lateinit var contentTitle: String
+    private lateinit var allImages : ArrayList<String>
     private lateinit var editor: SharedPreferences.Editor
     private lateinit var fab: FloatingActionButton
     private lateinit var appColors: AppColors
@@ -116,6 +118,7 @@ class ArticleFragment : Fragment() {
             contentTitle = allItems[pageNumber.toInt()].getTitleDecoded()
             contentImage = allItems[pageNumber.toInt()].getThumbnail(activity!!)
             contentSource = allItems[pageNumber.toInt()].sourceAndDateText()
+            allImages = allItems[pageNumber.toInt()].getImages()
 
             prefs = PreferenceManager.getDefaultSharedPreferences(activity)
             editor = prefs.edit()
@@ -545,10 +548,9 @@ class ArticleFragment : Fragment() {
     fun performClick(): Boolean {
         if (rootView!!.webcontent.hitTestResult.type == WebView.HitTestResult.IMAGE_TYPE ||
                 rootView!!.webcontent.hitTestResult.type == WebView.HitTestResult.SRC_IMAGE_ANCHOR_TYPE) {
-            //TODO: Transfer all images in the webpage to the Image fragment
-            var allImages = ArrayList<String>()
-            allImages.add(rootView!!.webcontent.hitTestResult.extra.toString())
-            val position : Int = 0
+
+            val position : Int = allImages.indexOf(rootView!!.webcontent.hitTestResult.extra)
+
 
             fragmentManager!!.beginTransaction().replace(R.id.reader_activity_view, ImageFragment.newInstance(position, allImages)).addToBackStack(null).commit()
             return false

--- a/app/src/main/java/apps/amine/bou/readerforselfoss/fragments/ImageFragment.kt
+++ b/app/src/main/java/apps/amine/bou/readerforselfoss/fragments/ImageFragment.kt
@@ -28,6 +28,8 @@ class ImageFragment : Fragment() {
         val view : View = inflater.inflate(R.layout.fragment_image, container, false)
 
         view.webcontent.visibility = View.VISIBLE
+        view.webcontent.settings.setLoadWithOverviewMode(true)
+        view.webcontent.settings.setUseWideViewPort(true)
         view.webcontent.loadUrl(allImages[0])
 
         return view

--- a/app/src/main/java/apps/amine/bou/readerforselfoss/fragments/ImageFragment.kt
+++ b/app/src/main/java/apps/amine/bou/readerforselfoss/fragments/ImageFragment.kt
@@ -6,6 +6,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import apps.amine.bou.readerforselfoss.R
 import kotlinx.android.synthetic.main.fragment_article.view.webcontent
+import kotlin.math.abs
 
 class ImageFragment : Fragment() {
 
@@ -31,6 +32,28 @@ class ImageFragment : Fragment() {
         view.webcontent.settings.setSupportZoom(true)
         view.webcontent.settings.setBuiltInZoomControls(true)
         view.webcontent.settings.setDisplayZoomControls(false)
+
+        val gestureDetector = GestureDetector(activity, object : GestureDetector.SimpleOnGestureListener() {
+            override fun onFling(e1: MotionEvent?, e2: MotionEvent?, velocityX: Float, velocityY: Float): Boolean {
+                val SWIPE_MIN_DISTANCE = 120
+                val SWIPE_MAX_OFF_PATH = 250
+                val SWIPE_THRESHOLD_VELOCITY = 200
+                if (abs(e1!!.y - e2!!.y) > SWIPE_MAX_OFF_PATH)
+                    return false
+                if (e1.x - e2.x > SWIPE_MIN_DISTANCE
+                        && abs(velocityX) > SWIPE_THRESHOLD_VELOCITY) {
+                    changeImage(1)
+                }
+                else if (e2.x - e1.x > SWIPE_MIN_DISTANCE
+                        && abs(velocityX) > SWIPE_THRESHOLD_VELOCITY) {
+                    changeImage(-1)
+                }
+
+                return super.onFling(e1, e2, velocityX, velocityY);
+            }
+        })
+        view.webcontent.setOnTouchListener { _, event -> gestureDetector.onTouchEvent(event)}
+
         view.webcontent.loadUrl(allImages[position])
 
         return view
@@ -43,6 +66,16 @@ class ImageFragment : Fragment() {
     override fun onDestroy() {
         (activity as AppCompatActivity).supportActionBar?.setDisplayShowTitleEnabled(true)
         super.onDestroy()
+    }
+
+    fun changeImage(change : Int) {
+        position += change
+        if (position < 0 || position >= allImages.size) {
+            position -= change
+        }
+        else {
+            view!!.webcontent.loadUrl(allImages[position])
+        }
     }
 
     companion object {

--- a/app/src/main/java/apps/amine/bou/readerforselfoss/fragments/ImageFragment.kt
+++ b/app/src/main/java/apps/amine/bou/readerforselfoss/fragments/ImageFragment.kt
@@ -7,10 +7,8 @@ import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import apps.amine.bou.readerforselfoss.R
-import apps.amine.bou.readerforselfoss.api.selfoss.Item
-import kotlinx.android.synthetic.main.fragment_article.*
-import kotlinx.android.synthetic.main.fragment_article.view.*
-import retrofit2.http.Url
+import kotlinx.android.synthetic.main.fragment_article.view.webcontent
+import kotlinx.android.synthetic.main.fragment_image.view.*
 
 class ImageFragment : Fragment() {
 
@@ -28,6 +26,10 @@ class ImageFragment : Fragment() {
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         (activity as AppCompatActivity).supportActionBar?.hide()
         val view : View = inflater.inflate(R.layout.fragment_image, container, false)
+
+        view.backButton.setOnClickListener() {
+            fragmentManager!!.popBackStackImmediate()
+        }
 
         view.webcontent.visibility = View.VISIBLE
         view.webcontent.settings.setLoadWithOverviewMode(true)

--- a/app/src/main/java/apps/amine/bou/readerforselfoss/fragments/ImageFragment.kt
+++ b/app/src/main/java/apps/amine/bou/readerforselfoss/fragments/ImageFragment.kt
@@ -1,14 +1,11 @@
 package apps.amine.bou.readerforselfoss.fragments
 
 import android.os.Bundle
-import android.view.LayoutInflater
-import android.view.View
-import android.view.ViewGroup
+import android.view.*
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import apps.amine.bou.readerforselfoss.R
 import kotlinx.android.synthetic.main.fragment_article.view.webcontent
-import kotlinx.android.synthetic.main.fragment_image.view.*
 
 class ImageFragment : Fragment() {
 
@@ -17,6 +14,7 @@ class ImageFragment : Fragment() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        setHasOptionsMenu(true)
 
         position = arguments!!.getInt("position")
         allImages = arguments!!.getStringArrayList("allImages")
@@ -24,12 +22,8 @@ class ImageFragment : Fragment() {
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        (activity as AppCompatActivity).supportActionBar?.hide()
+        (activity as AppCompatActivity).supportActionBar?.setDisplayShowTitleEnabled(false)
         val view : View = inflater.inflate(R.layout.fragment_image, container, false)
-
-        view.backButton.setOnClickListener() {
-            fragmentManager!!.popBackStackImmediate()
-        }
 
         view.webcontent.visibility = View.VISIBLE
         view.webcontent.settings.setLoadWithOverviewMode(true)
@@ -42,8 +36,12 @@ class ImageFragment : Fragment() {
         return view
     }
 
+    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
+                menu.clear()
+    }
+
     override fun onDestroy() {
-        (activity as AppCompatActivity).supportActionBar?.show()
+        (activity as AppCompatActivity).supportActionBar?.setDisplayShowTitleEnabled(true)
         super.onDestroy()
     }
 

--- a/app/src/main/java/apps/amine/bou/readerforselfoss/fragments/ImageFragment.kt
+++ b/app/src/main/java/apps/amine/bou/readerforselfoss/fragments/ImageFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import apps.amine.bou.readerforselfoss.R
 import apps.amine.bou.readerforselfoss.api.selfoss.Item
@@ -25,6 +26,7 @@ class ImageFragment : Fragment() {
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        (activity as AppCompatActivity).supportActionBar?.hide()
         val view : View = inflater.inflate(R.layout.fragment_image, container, false)
 
         view.webcontent.visibility = View.VISIBLE
@@ -33,6 +35,11 @@ class ImageFragment : Fragment() {
         view.webcontent.loadUrl(allImages[0])
 
         return view
+    }
+
+    override fun onDestroy() {
+        (activity as AppCompatActivity).supportActionBar?.show()
+        super.onDestroy()
     }
 
     companion object {

--- a/app/src/main/java/apps/amine/bou/readerforselfoss/fragments/ImageFragment.kt
+++ b/app/src/main/java/apps/amine/bou/readerforselfoss/fragments/ImageFragment.kt
@@ -1,130 +1,47 @@
 package apps.amine.bou.readerforselfoss.fragments
 
-import android.graphics.Bitmap
 import android.os.Bundle
 import android.view.*
-import android.webkit.WebResourceResponse
-import android.webkit.WebView
-import android.webkit.WebViewClient
-import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import apps.amine.bou.readerforselfoss.R
-import apps.amine.bou.readerforselfoss.utils.glide.getBitmapInputStream
 import com.bumptech.glide.Glide
 import com.bumptech.glide.load.engine.DiskCacheStrategy
 import com.bumptech.glide.request.RequestOptions
-import kotlinx.android.synthetic.main.fragment_article.view.webcontent
-import java.util.concurrent.ExecutionException
-import kotlin.math.abs
+import kotlinx.android.synthetic.main.fragment_image.view.*
 
 class ImageFragment : Fragment() {
 
-    private var position: Int = 0
-    private lateinit var allImages: ArrayList<String>
+    private lateinit var imageUrl : String
+    private val glideOptions = RequestOptions.diskCacheStrategyOf(DiskCacheStrategy.ALL)
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setHasOptionsMenu(true)
 
-        position = arguments!!.getInt("position")
-        allImages = arguments!!.getStringArrayList("allImages")
-
+        imageUrl = arguments!!.getString("imageUrl")
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        (activity as AppCompatActivity).supportActionBar?.setDisplayShowTitleEnabled(false)
         val view : View = inflater.inflate(R.layout.fragment_image, container, false)
 
-        view.webcontent.visibility = View.VISIBLE
-        view.webcontent.settings.setLoadWithOverviewMode(true)
-        view.webcontent.settings.setUseWideViewPort(true)
-        view.webcontent.settings.setSupportZoom(true)
-        view.webcontent.settings.setBuiltInZoomControls(true)
-        view.webcontent.settings.setDisplayZoomControls(false)
-
-        view.webcontent.webViewClient = object : WebViewClient() {
-            override fun shouldInterceptRequest(view: WebView?, url: String): WebResourceResponse? {
-                val glideOptions = RequestOptions.diskCacheStrategyOf(DiskCacheStrategy.ALL)
-                if (url.toLowerCase().contains(".jpg") || url.toLowerCase().contains(".jpeg")) {
-                    try {
-                        val image = Glide.with(view).asBitmap().apply(glideOptions).load(url).submit().get()
-                        return WebResourceResponse("image/jpg", "UTF-8", getBitmapInputStream(image, Bitmap.CompressFormat.JPEG))
-                    }catch ( e : ExecutionException) {}
-                }
-                else if (url.toLowerCase().contains(".png")) {
-                    try {
-                        val image = Glide.with(view).asBitmap().apply(glideOptions).load(url).submit().get()
-                        return WebResourceResponse("image/jpg", "UTF-8", getBitmapInputStream(image, Bitmap.CompressFormat.PNG))
-                    }catch ( e : ExecutionException) {}
-                }
-                else if (url.toLowerCase().contains(".webp")) {
-                    try {
-                        val image = Glide.with(view).asBitmap().apply(glideOptions).load(url).submit().get()
-                        return WebResourceResponse("image/jpg", "UTF-8", getBitmapInputStream(image, Bitmap.CompressFormat.WEBP))
-                    }catch ( e : ExecutionException) {}
-                }
-
-                return super.shouldInterceptRequest(view, url)
-            }
-        }
-
-        val gestureDetector = GestureDetector(activity, object : GestureDetector.SimpleOnGestureListener() {
-            override fun onFling(e1: MotionEvent?, e2: MotionEvent?, velocityX: Float, velocityY: Float): Boolean {
-                val SWIPE_MIN_DISTANCE = 120
-                val SWIPE_MAX_OFF_PATH = 250
-                val SWIPE_THRESHOLD_VELOCITY = 200
-                if (abs(e1!!.y - e2!!.y) > SWIPE_MAX_OFF_PATH)
-                    return false
-                if (e1.x - e2.x > SWIPE_MIN_DISTANCE
-                        && abs(velocityX) > SWIPE_THRESHOLD_VELOCITY) {
-                    changeImage(1)
-                }
-                else if (e2.x - e1.x > SWIPE_MIN_DISTANCE
-                        && abs(velocityX) > SWIPE_THRESHOLD_VELOCITY) {
-                    changeImage(-1)
-                }
-
-                return super.onFling(e1, e2, velocityX, velocityY);
-            }
-        })
-        view.webcontent.setOnTouchListener { _, event -> gestureDetector.onTouchEvent(event)}
-
-        view.webcontent.loadUrl(allImages[position])
+        view.photoView.visibility = View.VISIBLE
+        Glide.with(activity)
+                .asBitmap()
+                .apply(glideOptions)
+                .load(imageUrl)
+                .into(view.photoView)
 
         return view
     }
 
-    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
-                menu.clear()
-    }
-
-    override fun onDestroy() {
-        (activity as AppCompatActivity).supportActionBar?.setDisplayShowTitleEnabled(true)
-        super.onDestroy()
-    }
-
-    fun changeImage(change : Int) {
-        position += change
-        if (position < 0 || position >= allImages.size) {
-            position -= change
-        }
-        else {
-            view!!.webcontent.loadUrl(allImages[position])
-        }
-    }
-
     companion object {
-        private const val ARG_POSITION = "position"
-        private const val ARG_IMAGES = "allImages"
+        private const val ARG_IMAGE = "imageUrl"
 
         fun newInstance(
-                position: Int,
-                allImages: ArrayList<String>
+                imageUrl : String
         ): ImageFragment {
             val fragment = ImageFragment()
             val args = Bundle()
-            args.putInt(ARG_POSITION, position)
-            args.putStringArrayList(ARG_IMAGES, allImages)
+            args.putString(ARG_IMAGE, imageUrl)
             fragment.arguments = args
             return fragment
         }

--- a/app/src/main/java/apps/amine/bou/readerforselfoss/fragments/ImageFragment.kt
+++ b/app/src/main/java/apps/amine/bou/readerforselfoss/fragments/ImageFragment.kt
@@ -34,6 +34,9 @@ class ImageFragment : Fragment() {
         view.webcontent.visibility = View.VISIBLE
         view.webcontent.settings.setLoadWithOverviewMode(true)
         view.webcontent.settings.setUseWideViewPort(true)
+        view.webcontent.settings.setSupportZoom(true)
+        view.webcontent.settings.setBuiltInZoomControls(true)
+        view.webcontent.settings.setDisplayZoomControls(false)
         view.webcontent.loadUrl(allImages[0])
 
         return view

--- a/app/src/main/java/apps/amine/bou/readerforselfoss/fragments/ImageFragment.kt
+++ b/app/src/main/java/apps/amine/bou/readerforselfoss/fragments/ImageFragment.kt
@@ -1,0 +1,52 @@
+package apps.amine.bou.readerforselfoss.fragments
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import apps.amine.bou.readerforselfoss.R
+import apps.amine.bou.readerforselfoss.api.selfoss.Item
+import kotlinx.android.synthetic.main.fragment_article.*
+import kotlinx.android.synthetic.main.fragment_article.view.*
+import retrofit2.http.Url
+
+class ImageFragment : Fragment() {
+
+    private lateinit var position: Number
+    private lateinit var allImages: ArrayList<String>
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        position = arguments!!.getInt("position")
+        allImages = arguments!!.getStringArrayList("allImages")
+
+    }
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        val view : View = inflater.inflate(R.layout.fragment_image, container, false)
+
+        view.webcontent.visibility = View.VISIBLE
+        view.webcontent.loadUrl(allImages[0])
+
+        return view
+    }
+
+    companion object {
+        private const val ARG_POSITION = "position"
+        private const val ARG_IMAGES = "allImages"
+
+        fun newInstance(
+                position: Int,
+                allImages: ArrayList<String>
+        ): ImageFragment {
+            val fragment = ImageFragment()
+            val args = Bundle()
+            args.putInt(ARG_POSITION, position)
+            args.putStringArrayList(ARG_IMAGES, allImages)
+            fragment.arguments = args
+            return fragment
+        }
+    }
+}

--- a/app/src/main/java/apps/amine/bou/readerforselfoss/fragments/ImageFragment.kt
+++ b/app/src/main/java/apps/amine/bou/readerforselfoss/fragments/ImageFragment.kt
@@ -9,7 +9,7 @@ import kotlinx.android.synthetic.main.fragment_article.view.webcontent
 
 class ImageFragment : Fragment() {
 
-    private lateinit var position: Number
+    private var position: Int = 0
     private lateinit var allImages: ArrayList<String>
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -31,7 +31,7 @@ class ImageFragment : Fragment() {
         view.webcontent.settings.setSupportZoom(true)
         view.webcontent.settings.setBuiltInZoomControls(true)
         view.webcontent.settings.setDisplayZoomControls(false)
-        view.webcontent.loadUrl(allImages[0])
+        view.webcontent.loadUrl(allImages[position])
 
         return view
     }

--- a/app/src/main/java/apps/amine/bou/readerforselfoss/fragments/ImageFragment.kt
+++ b/app/src/main/java/apps/amine/bou/readerforselfoss/fragments/ImageFragment.kt
@@ -1,11 +1,20 @@
 package apps.amine.bou.readerforselfoss.fragments
 
+import android.graphics.Bitmap
 import android.os.Bundle
 import android.view.*
+import android.webkit.WebResourceResponse
+import android.webkit.WebView
+import android.webkit.WebViewClient
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import apps.amine.bou.readerforselfoss.R
+import apps.amine.bou.readerforselfoss.utils.glide.getBitmapInputStream
+import com.bumptech.glide.Glide
+import com.bumptech.glide.load.engine.DiskCacheStrategy
+import com.bumptech.glide.request.RequestOptions
 import kotlinx.android.synthetic.main.fragment_article.view.webcontent
+import java.util.concurrent.ExecutionException
 import kotlin.math.abs
 
 class ImageFragment : Fragment() {
@@ -32,6 +41,32 @@ class ImageFragment : Fragment() {
         view.webcontent.settings.setSupportZoom(true)
         view.webcontent.settings.setBuiltInZoomControls(true)
         view.webcontent.settings.setDisplayZoomControls(false)
+
+        view.webcontent.webViewClient = object : WebViewClient() {
+            override fun shouldInterceptRequest(view: WebView?, url: String): WebResourceResponse? {
+                val glideOptions = RequestOptions.diskCacheStrategyOf(DiskCacheStrategy.ALL)
+                if (url.toLowerCase().contains(".jpg") || url.toLowerCase().contains(".jpeg")) {
+                    try {
+                        val image = Glide.with(view).asBitmap().apply(glideOptions).load(url).submit().get()
+                        return WebResourceResponse("image/jpg", "UTF-8", getBitmapInputStream(image, Bitmap.CompressFormat.JPEG))
+                    }catch ( e : ExecutionException) {}
+                }
+                else if (url.toLowerCase().contains(".png")) {
+                    try {
+                        val image = Glide.with(view).asBitmap().apply(glideOptions).load(url).submit().get()
+                        return WebResourceResponse("image/jpg", "UTF-8", getBitmapInputStream(image, Bitmap.CompressFormat.PNG))
+                    }catch ( e : ExecutionException) {}
+                }
+                else if (url.toLowerCase().contains(".webp")) {
+                    try {
+                        val image = Glide.with(view).asBitmap().apply(glideOptions).load(url).submit().get()
+                        return WebResourceResponse("image/jpg", "UTF-8", getBitmapInputStream(image, Bitmap.CompressFormat.WEBP))
+                    }catch ( e : ExecutionException) {}
+                }
+
+                return super.shouldInterceptRequest(view, url)
+            }
+        }
 
         val gestureDetector = GestureDetector(activity, object : GestureDetector.SimpleOnGestureListener() {
             override fun onFling(e1: MotionEvent?, e2: MotionEvent?, velocityX: Float, velocityY: Float): Boolean {

--- a/app/src/main/java/apps/amine/bou/readerforselfoss/utils/glide/GlideUtils.kt
+++ b/app/src/main/java/apps/amine/bou/readerforselfoss/utils/glide/GlideUtils.kt
@@ -14,6 +14,9 @@ import com.bumptech.glide.load.model.GlideUrl
 import com.bumptech.glide.load.model.LazyHeaders
 import com.bumptech.glide.request.RequestOptions
 import com.bumptech.glide.request.target.BitmapImageViewTarget
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
 
 fun Context.bitmapCenterCrop(config: Config, url: String, iv: ImageView) =
     Glide.with(this)
@@ -56,4 +59,11 @@ fun RequestManager.loadMaybeBasicAuth(config: Config, url: String): RequestBuild
     }
     val glideUrl = GlideUrl(url, builder.build())
     return this.load(glideUrl)
+}
+
+fun getBitmapInputStream(bitmap:Bitmap,compressFormat: Bitmap.CompressFormat): InputStream {
+    val byteArrayOutputStream = ByteArrayOutputStream()
+    bitmap.compress(compressFormat, 80, byteArrayOutputStream)
+    val bitmapData: ByteArray = byteArrayOutputStream.toByteArray()
+    return ByteArrayInputStream(bitmapData)
 }

--- a/app/src/main/res/layout/activity_image.xml
+++ b/app/src/main/res/layout/activity_image.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appBarLayout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/toolBar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            app:popupTheme="?attr/toolbarPopupTheme"
+            app:theme="@style/ToolBarStyle" />
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <androidx.viewpager.widget.ViewPager
+        android:id="@+id/pager"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/appBarLayout" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_image.xml
+++ b/app/src/main/res/layout/fragment_image.xml
@@ -4,9 +4,13 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <WebView
-        android:id="@+id/webcontent"
+    <com.github.chrisbanes.photoview.PhotoView
+        android:id="@+id/photoView"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" >
-    </WebView>
+        android:layout_height="match_parent"
+        android:layout_centerVertical="true"
+        android:layout_centerHorizontal="true"
+        android:background="@android:color/black"
+        app:srcCompat="@android:drawable/screen_background_dark" />
+
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/fragment_image.xml
+++ b/app/src/main/res/layout/fragment_image.xml
@@ -1,23 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:background="@android:color/black"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
-
-    <com.google.android.material.floatingactionbutton.FloatingActionButton
-        android:id="@+id/backButton"
-        style="?android:borderlessButtonStyle"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:clickable="true"
-        app:background="@android:color/transparent"
-        app:backgroundTint="@null"
-        app:rippleColor="@null"
-        app:srcCompat="?attr/homeAsUpIndicator" />
 
     <WebView
         android:id="@+id/webcontent"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="match_parent" >
+    </WebView>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/fragment_image.xml
+++ b/app/src/main/res/layout/fragment_image.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android" android:layout_width="match_parent"
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
     android:layout_height="match_parent">
 
     <WebView
         android:id="@+id/webcontent"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
-</androidx.constraintlayout.widget.ConstraintLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_image.xml
+++ b/app/src/main/res/layout/fragment_image.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android" android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <WebView
+        android:id="@+id/webcontent"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_image.xml
+++ b/app/src/main/res/layout/fragment_image.xml
@@ -1,11 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:background="@android:color/black"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
+
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/backButton"
+        style="?android:borderlessButtonStyle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:clickable="true"
+        app:background="@android:color/transparent"
+        app:backgroundTint="@null"
+        app:rippleColor="@null"
+        app:srcCompat="?attr/homeAsUpIndicator" />
 
     <WebView
         android:id="@+id/webcontent"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
-</LinearLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
## Types of changes

- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] This is **NOT** translation related. (See [here](https://github.com/aminecmi/ReaderforSelfoss/pull/170#issuecomment-355715654))

This closes issue #178

I started implementing a function to detect taps on images in webview, it still doesn't do anything though.

To expand the image I looked at the Pocket application who does it opening the image in full screen and including three buttons:  one to close the image and the other two to go to the next/previous image.
If you like this behavior I might start preparing a fragment to show the image in fullscreen.