### PR TITLE
Fix crash when a feed has no icon

### DIFF
--- a/app/src/main/java/apps/amine/bou/readerforselfoss/api/selfoss/SelfossModels.kt
+++ b/app/src/main/java/apps/amine/bou/readerforselfoss/api/selfoss/SelfossModels.kt
@@ -69,7 +69,7 @@ data class Item(
     @SerializedName("unread") val unread: Boolean,
     @SerializedName("starred") var starred: Boolean,
     @SerializedName("thumbnail") val thumbnail: String?,
-    @SerializedName("icon") val icon: String,
+    @SerializedName("icon") val icon: String?,
     @SerializedName("link") val link: String,
     @SerializedName("sourcetitle") val sourcetitle: String,
     @SerializedName("tags") val tags: SelfossTagType

--- a/app/src/main/java/apps/amine/bou/readerforselfoss/persistence/entities/ItemEntity.kt
+++ b/app/src/main/java/apps/amine/bou/readerforselfoss/persistence/entities/ItemEntity.kt
@@ -22,7 +22,7 @@ data class ItemEntity(
     @ColumnInfo(name = "thumbnail")
     val thumbnail: String?,
     @ColumnInfo(name = "icon")
-    val icon: String,
+    val icon: String?,
     @ColumnInfo(name = "link")
     val link: String,
     @ColumnInfo(name = "sourcetitle")


### PR DESCRIPTION
## Types of changes

- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] This is **NOT** translation related. (See [here](https://github.com/aminecmi/ReaderforSelfoss/pull/170#issuecomment-355715654))

This closes issue #310

This problem is similar to what I reported in #310, when a feed element has no icon associated to it the app crashes. The solution is analogue to #311.
I tested this edit on my phone and everything seems to work. I noticed this problem as yesterday one of my feeds sent a new entry with no icon.