### PR TITLE
Fix crash when loading image that doesn't exist

### DIFF
--- a/app/src/main/java/apps/amine/bou/readerforselfoss/api/selfoss/SelfossModels.kt
+++ b/app/src/main/java/apps/amine/bou/readerforselfoss/api/selfoss/SelfossModels.kt
@@ -156,7 +156,7 @@ data class Item(
     fun preloadImages(context: Context) : Boolean {
         val imageUrls = this.getImages()
 
-        val glideOptions = RequestOptions.diskCacheStrategyOf(DiskCacheStrategy.ALL)
+        val glideOptions = RequestOptions.diskCacheStrategyOf(DiskCacheStrategy.ALL).timeout(10000)
 
 
         try {
@@ -165,16 +165,6 @@ data class Item(
                     val image = Glide.with(context).asBitmap()
                             .apply(glideOptions)
                             .load(url).submit()
-
-                    var counter = 0
-                    while (!image.isDone) {
-                        if (counter > 30) {
-                            image.cancel(true)
-                            break
-                        }
-                        Thread.sleep(10)
-                        counter += 1
-                    }
                 }
             }
         } catch (e : Error) {

--- a/app/src/main/java/apps/amine/bou/readerforselfoss/api/selfoss/SelfossModels.kt
+++ b/app/src/main/java/apps/amine/bou/readerforselfoss/api/selfoss/SelfossModels.kt
@@ -164,7 +164,17 @@ data class Item(
                 if ( URLUtil.isValidUrl(url)) {
                     val image = Glide.with(context).asBitmap()
                             .apply(glideOptions)
-                            .load(url).submit().get()
+                            .load(url).submit()
+
+                    var counter = 0
+                    while (!image.isDone) {
+                        if (counter > 30) {
+                            image.cancel(true)
+                            break
+                        }
+                        Thread.sleep(10)
+                        counter += 1
+                    }
                 }
             }
         } catch (e : Error) {


### PR DESCRIPTION
## Types of changes

- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] This is **NOT** translation related. (See [here](https://github.com/aminecmi/ReaderforSelfoss/pull/170#issuecomment-355715654))

This closes issue #328

This seems to fix the issue. The get() command was only needed to wait for the image to complete downloading, the image itself was not really used.
Since that is the function that was causing trouble I substituted it with a loop that keeps checking whether the download is complete.
I may see some problems arising if someone is downloading large pictures on slow networks, as those may never be downloaded.