### PR TITLE
Download read and starred items

### DIFF
--- a/app/src/main/java/apps/amine/bou/readerforselfoss/HomeActivity.kt
+++ b/app/src/main/java/apps/amine/bou/readerforselfoss/HomeActivity.kt
@@ -357,7 +357,7 @@ class HomeActivity : AppCompatActivity(), SearchView.OnQueryTextListener {
     }
 
     private fun getAndStoreAllItems() {
-        api.allItems().enqueue(object : Callback<List<Item>> {
+        api.allNewItems().enqueue(object : Callback<List<Item>> {
             override fun onFailure(call: Call<List<Item>>, t: Throwable) {
             }
 
@@ -373,6 +373,46 @@ class HomeActivity : AppCompatActivity(), SearchView.OnQueryTextListener {
                         db.itemsDao().deleteAllItems()
                         db.itemsDao()
                             .insertAllItems(*(apiItems.map { it.toEntity() }).toTypedArray())
+                    }
+                }
+            }
+        })
+
+        api.allReadItems().enqueue(object : Callback<List<Item>> {
+            override fun onFailure(call: Call<List<Item>>, t: Throwable) {
+            }
+
+            override fun onResponse(
+                    call: Call<List<Item>>,
+                    response: Response<List<Item>>
+            ) {
+                thread {
+                    if (response.body() != null) {
+                        val apiItems = (response.body() as ArrayList<Item>).filter {
+                            maybeTagFilter != null || filter(it.tags.tags)
+                        } as ArrayList<Item>
+                        db.itemsDao()
+                                .insertAllItems(*(apiItems.map { it.toEntity() }).toTypedArray())
+                    }
+                }
+            }
+        })
+
+        api.allStarredItems().enqueue(object : Callback<List<Item>> {
+            override fun onFailure(call: Call<List<Item>>, t: Throwable) {
+            }
+
+            override fun onResponse(
+                    call: Call<List<Item>>,
+                    response: Response<List<Item>>
+            ) {
+                thread {
+                    if (response.body() != null) {
+                        val apiItems = (response.body() as ArrayList<Item>).filter {
+                            maybeTagFilter != null || filter(it.tags.tags)
+                        } as ArrayList<Item>
+                        db.itemsDao()
+                                .insertAllItems(*(apiItems.map { it.toEntity() }).toTypedArray())
                     }
                 }
             }

--- a/app/src/main/java/apps/amine/bou/readerforselfoss/HomeActivity.kt
+++ b/app/src/main/java/apps/amine/bou/readerforselfoss/HomeActivity.kt
@@ -365,16 +365,7 @@ class HomeActivity : AppCompatActivity(), SearchView.OnQueryTextListener {
                 call: Call<List<Item>>,
                 response: Response<List<Item>>
             ) {
-                thread {
-                    if (response.body() != null) {
-                        val apiItems = (response.body() as ArrayList<Item>).filter {
-                            maybeTagFilter != null || filter(it.tags.tags)
-                        } as ArrayList<Item>
-                        db.itemsDao().deleteAllItems()
-                        db.itemsDao()
-                            .insertAllItems(*(apiItems.map { it.toEntity() }).toTypedArray())
-                    }
-                }
+                enqueueArticles(response, true)
             }
         })
 
@@ -386,15 +377,7 @@ class HomeActivity : AppCompatActivity(), SearchView.OnQueryTextListener {
                     call: Call<List<Item>>,
                     response: Response<List<Item>>
             ) {
-                thread {
-                    if (response.body() != null) {
-                        val apiItems = (response.body() as ArrayList<Item>).filter {
-                            maybeTagFilter != null || filter(it.tags.tags)
-                        } as ArrayList<Item>
-                        db.itemsDao()
-                                .insertAllItems(*(apiItems.map { it.toEntity() }).toTypedArray())
-                    }
-                }
+                enqueueArticles(response, false)
             }
         })
 
@@ -406,17 +389,24 @@ class HomeActivity : AppCompatActivity(), SearchView.OnQueryTextListener {
                     call: Call<List<Item>>,
                     response: Response<List<Item>>
             ) {
-                thread {
-                    if (response.body() != null) {
-                        val apiItems = (response.body() as ArrayList<Item>).filter {
-                            maybeTagFilter != null || filter(it.tags.tags)
-                        } as ArrayList<Item>
-                        db.itemsDao()
-                                .insertAllItems(*(apiItems.map { it.toEntity() }).toTypedArray())
-                    }
-                }
+                enqueueArticles(response, false)
             }
         })
+    }
+
+    private fun enqueueArticles(response: Response<List<Item>>, clearDatabase: Boolean) {
+        thread {
+            if (response.body() != null) {
+                val apiItems = (response.body() as ArrayList<Item>).filter {
+                    maybeTagFilter != null || filter(it.tags.tags)
+                } as ArrayList<Item>
+                if (clearDatabase) {
+                    db.itemsDao().deleteAllItems()
+                }
+                db.itemsDao()
+                        .insertAllItems(*(apiItems.map { it.toEntity() }).toTypedArray())
+            }
+        }
     }
 
     override fun onStop() {

--- a/app/src/main/java/apps/amine/bou/readerforselfoss/api/selfoss/SelfossApi.kt
+++ b/app/src/main/java/apps/amine/bou/readerforselfoss/api/selfoss/SelfossApi.kt
@@ -172,6 +172,15 @@ class SelfossApi(
     fun allItems(): Call<List<Item>> =
         service.allItems(userName, password)
 
+    fun allNewItems(): Call<List<Item>> =
+            service.allTypeItems("unread", userName, password)
+
+    fun allReadItems(): Call<List<Item>> =
+            service.allTypeItems("read", userName, password)
+
+    fun allStarredItems(): Call<List<Item>> =
+            service.allTypeItems("starred", userName, password)
+
     private fun getItems(
         type: String,
         tag: String?,

--- a/app/src/main/java/apps/amine/bou/readerforselfoss/api/selfoss/SelfossApi.kt
+++ b/app/src/main/java/apps/amine/bou/readerforselfoss/api/selfoss/SelfossApi.kt
@@ -173,13 +173,13 @@ class SelfossApi(
         service.allItems(userName, password)
 
     fun allNewItems(): Call<List<Item>> =
-            service.allTypeItems("unread", userName, password)
+            getItems("unread", null, null, null, 200, 0)
 
     fun allReadItems(): Call<List<Item>> =
-            service.allTypeItems("read", userName, password)
+            getItems("read", null, null, null, 200, 0)
 
     fun allStarredItems(): Call<List<Item>> =
-            service.allTypeItems("starred", userName, password)
+            getItems("read", null, null, null, 200, 0)
 
     private fun getItems(
         type: String,

--- a/app/src/main/java/apps/amine/bou/readerforselfoss/api/selfoss/SelfossService.kt
+++ b/app/src/main/java/apps/amine/bou/readerforselfoss/api/selfoss/SelfossService.kt
@@ -28,6 +28,13 @@ internal interface SelfossService {
     ): Call<List<Item>>
 
     @GET("items")
+    fun allTypeItems(
+            @Query("type") type: String,
+            @Query("username") username: String,
+            @Query("password") password: String
+    ) : Call<List<Item>>
+
+    @GET("items")
     fun allItems(
         @Query("username") username: String,
         @Query("password") password: String

--- a/app/src/main/java/apps/amine/bou/readerforselfoss/api/selfoss/SelfossService.kt
+++ b/app/src/main/java/apps/amine/bou/readerforselfoss/api/selfoss/SelfossService.kt
@@ -28,13 +28,6 @@ internal interface SelfossService {
     ): Call<List<Item>>
 
     @GET("items")
-    fun allTypeItems(
-            @Query("type") type: String,
-            @Query("username") username: String,
-            @Query("password") password: String
-    ) : Call<List<Item>>
-
-    @GET("items")
     fun allItems(
         @Query("username") username: String,
         @Query("password") password: String

--- a/app/src/main/java/apps/amine/bou/readerforselfoss/background/background.kt
+++ b/app/src/main/java/apps/amine/bou/readerforselfoss/background/background.kt
@@ -129,6 +129,7 @@ class LoadingWorker(val context: Context, params: WorkerParameters) : Worker(con
                             val apiItems = (response.body() as ArrayList<Item>)
                             db.itemsDao()
                                     .insertAllItems(*(apiItems.map { it.toEntity() }).toTypedArray())
+                            apiItems.map { it.preloadImages(context) }
                         }
                         Timer("", false).schedule(4000) {
                             notificationManager.cancel(1)


### PR DESCRIPTION
## Types of changes

- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] This is **NOT** translation related. (See [here](https://github.com/aminecmi/ReaderforSelfoss/pull/170#issuecomment-355715654))

This closes issue #305 

The api of selfoss allows loading a maximum of 200 articles at a time. Loading all articles with no filtering allows to get the first 200 articles, but this may fetch no new or starred items if the newest 200 items have all been read already.
In order to make sure to get new and starred icons, we perform 3 calls to the api, one for unread items, one for read items and one for starred items. In this way in the database may be stored up to 600 items at any given time.
All images from these items get cached during the background sync.