### PR TITLE
Added option to prevent updating sources and tags.

### DIFF
--- a/app/src/main/java/apps/amine/bou/readerforselfoss/HomeActivity.kt
+++ b/app/src/main/java/apps/amine/bou/readerforselfoss/HomeActivity.kt
@@ -102,6 +102,7 @@ class HomeActivity : AppCompatActivity(), SearchView.OnQueryTextListener {
     private var infiniteScroll: Boolean = false
     private var lastFetchDone: Boolean = false
     private var itemsCaching: Boolean = false
+    private var updateSources: Boolean = true
     private var hiddenTags: List<String> = emptyList()
 
     private var periodicRefresh = false
@@ -426,6 +427,7 @@ class HomeActivity : AppCompatActivity(), SearchView.OnQueryTextListener {
         displayAccountHeader = sharedPref.getBoolean("account_header_displaying", false)
         infiniteScroll = sharedPref.getBoolean("infinite_loading", false)
         itemsCaching = sharedPref.getBoolean("items_caching", false)
+        updateSources = sharedPref.getBoolean("update_sources", true)
         hiddenTags = if (sharedPref.getString("hidden_tags", "")!!.isNotEmpty()) {
             sharedPref.getString("hidden_tags", "")!!.replace("\\s".toRegex(), "").split(",")
         } else {
@@ -762,7 +764,7 @@ class HomeActivity : AppCompatActivity(), SearchView.OnQueryTextListener {
             var sources: List<Source>?
 
             fun sourcesApiCall() {
-                if (this@HomeActivity.isNetworkAccessible(null, offlineShortcut)) {
+                if (this@HomeActivity.isNetworkAccessible(null, offlineShortcut) && updateSources) {
                     api.sources.enqueue(object : Callback<List<Source>> {
                         override fun onResponse(
                             call: Call<List<Source>>?,
@@ -785,7 +787,7 @@ class HomeActivity : AppCompatActivity(), SearchView.OnQueryTextListener {
                 }
             }
 
-            if (this@HomeActivity.isNetworkAccessible(null, offlineShortcut)) {
+            if (this@HomeActivity.isNetworkAccessible(null, offlineShortcut) && updateSources) {
                 api.tags.enqueue(object : Callback<List<Tag>> {
                     override fun onResponse(
                         call: Call<List<Tag>>,

--- a/app/src/main/java/apps/amine/bou/readerforselfoss/HomeActivity.kt
+++ b/app/src/main/java/apps/amine/bou/readerforselfoss/HomeActivity.kt
@@ -730,6 +730,7 @@ class HomeActivity : AppCompatActivity(), SearchView.OnQueryTextListener {
                     if (maybeDrawerData.tags != null) {
                         thread {
                             val tagEntities = maybeDrawerData.tags.map { it.toEntity() }
+                            db.drawerDataDao().deleteAllTags()
                             db.drawerDataDao().insertAllTags(*tagEntities.toTypedArray())
                         }
                     }
@@ -737,6 +738,7 @@ class HomeActivity : AppCompatActivity(), SearchView.OnQueryTextListener {
                         thread {
                             val sourceEntities =
                                 maybeDrawerData.sources.map { it.toEntity() }
+                            db.drawerDataDao().deleteAllSources()
                             db.drawerDataDao().insertAllSources(*sourceEntities.toTypedArray())
                         }
                     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -140,6 +140,8 @@
     <string name="pref_switch_items_caching_off">Articles won\'t be saved to the device memory, and the app won\'t be usable offline.</string>
     <string name="pref_switch_items_caching_on">Articles will be saved to the device memory and will be used for offline use.</string>
     <string name="pref_switch_items_caching">Save items for offline use</string>
+    <string name="pref_switch_update_sources">Check for new sources and tags</string>
+    <string name="pref_switch_update_sources_summary">Disable this if your server is receiving excessive amounts of database queries.</string>
     <string name="no_network_connectivity">Not connected !</string>
     <string name="pref_switch_periodic_refresh">Sync articles</string>
     <string name="pref_switch_periodic_refresh_off">Articles will not be synced in the background</string>

--- a/app/src/main/res/xml/pref_offline.xml
+++ b/app/src/main/res/xml/pref_offline.xml
@@ -34,4 +34,10 @@
         android:key="notify_new_items"
         android:dependency="periodic_refresh"
         android:title="@string/pref_switch_notify_new_items" />
+
+    <SwitchPreference
+        android:defaultValue="true"
+        android:key="update_sources"
+        android:summary="@string/pref_switch_update_sources_summary"
+        android:title="@string/pref_switch_update_sources" />
 </PreferenceScreen>


### PR DESCRIPTION
## Types of changes

- [ x ] I have read the **CONTRIBUTING** document.
- [ x ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ x ] This is **NOT** translation related. (See [here](https://github.com/aminecmi/ReaderforSelfoss/pull/170#issuecomment-355715654))

This closes issue #309

I added an option in the offline settings that blocks all calls to sources and tags in the Home activity.
If this option is disabled and a source is added, the new source will not be displayed in the side drawer but the items of that source will be available and can be read.
In order to obtain the new sources the option has to be re-enabled and then one refresh has to be performed.
A button to manually refresh sources and tags is trivial to add if needed.
I will actually disable this option when I use it as the refresh is faster.

I tested these changes on my phone and on an emulated image running android with api 30.