### PR TITLE
Fetch articles only when the home activity is created.

### DIFF
--- a/app/src/main/java/apps/amine/bou/readerforselfoss/HomeActivity.kt
+++ b/app/src/main/java/apps/amine/bou/readerforselfoss/HomeActivity.kt
@@ -189,6 +189,8 @@ class HomeActivity : AppCompatActivity(), SearchView.OnQueryTextListener {
         handleDrawer()
 
         handleSwipeRefreshLayout()
+
+        getElementsAccordingToTab()
     }
 
     private fun handleSwipeRefreshLayout() {
@@ -349,8 +351,6 @@ class HomeActivity : AppCompatActivity(), SearchView.OnQueryTextListener {
         }
 
         handleBottomBarActions()
-
-        getElementsAccordingToTab()
 
         handleRecurringTask()
 


### PR DESCRIPTION
## Types of changes

- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] This is **NOT** translation related. (See [here](https://github.com/aminecmi/ReaderforSelfoss/pull/170#issuecomment-355715654))

This closes issue #277

Articles are fetched only when the activity is first created or when you switch between tabs.
Navigating the app will no longer cause loading of articles, also sharing or opening it from background will not.
Strangely, closing the settings activity will still cause the articles to update.
This way however people who keep the application always open in background will have to manually refresh the articles when they open the app as that won't happen automatically anymore.

I tried testing all possible interactions on my phone and didn't find anything strange happening, but it would be best if you checked as well.