### PR TITLE
Load settings when the home activity is created.

### DIFF
--- a/app/src/main/java/apps/amine/bou/readerforselfoss/HomeActivity.kt
+++ b/app/src/main/java/apps/amine/bou/readerforselfoss/HomeActivity.kt
@@ -190,6 +190,8 @@ class HomeActivity : AppCompatActivity(), SearchView.OnQueryTextListener {
 
         handleSwipeRefreshLayout()
 
+        handleSharedPrefs()
+
         getElementsAccordingToTab()
     }
 
@@ -335,8 +337,6 @@ class HomeActivity : AppCompatActivity(), SearchView.OnQueryTextListener {
         sharedPref = PreferenceManager.getDefaultSharedPreferences(this)
 
         editor = settings.edit()
-
-        handleSharedPrefs()
 
         handleDrawerItems()
 


### PR DESCRIPTION
## Types of changes

- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] This is **NOT** translation related. (See [here](https://github.com/aminecmi/ReaderforSelfoss/pull/170#issuecomment-355715654))

In #335 I introduced a bug: when the application is started without an internet connection no articles are immediately displayed even if there are some available in the database. To show the you would have to perform a refresh or switch tab.
This PR fixes that bug loading the settings before the articles are loaded as soon as the app is opened. Articles are therefore shown as soon as you open the app, even if you have no internet connection.