### PR TITLE
Refresh the articles if using Mark On Scroll.

### DIFF
--- a/app/src/main/java/apps/amine/bou/readerforselfoss/HomeActivity.kt
+++ b/app/src/main/java/apps/amine/bou/readerforselfoss/HomeActivity.kt
@@ -103,6 +103,7 @@ class HomeActivity : AppCompatActivity(), SearchView.OnQueryTextListener {
     private var lastFetchDone: Boolean = false
     private var itemsCaching: Boolean = false
     private var updateSources: Boolean = true
+    private var markOnScroll: Boolean = false
     private var hiddenTags: List<String> = emptyList()
     private var apiVersionMajor: Int = 0
 
@@ -381,6 +382,10 @@ class HomeActivity : AppCompatActivity(), SearchView.OnQueryTextListener {
         handleRecurringTask()
 
         handleOfflineActions()
+
+        if (markOnScroll) {
+            getElementsAccordingToTab()
+        }
     }
 
     private fun getAndStoreAllItems() {
@@ -454,6 +459,7 @@ class HomeActivity : AppCompatActivity(), SearchView.OnQueryTextListener {
         infiniteScroll = sharedPref.getBoolean("infinite_loading", false)
         itemsCaching = sharedPref.getBoolean("items_caching", false)
         updateSources = sharedPref.getBoolean("update_sources", true)
+        markOnScroll = sharedPref.getBoolean("mark_on_scroll", false)
         hiddenTags = if (sharedPref.getString("hidden_tags", "")!!.isNotEmpty()) {
             sharedPref.getString("hidden_tags", "")!!.replace("\\s".toRegex(), "").split(",")
         } else {


### PR DESCRIPTION
## Types of changes

- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] This is **NOT** translation related. (See [here](https://github.com/aminecmi/ReaderforSelfoss/pull/170#issuecomment-355715654))

This closes issue #341

Just a quick fix: if Mark On Scroll is enabled the home activity will refresh the articles every time it is opened.
Eventually I'll make it work without the refresh.